### PR TITLE
MAINT: remove %matplotlib inline and contents directive

### DIFF
--- a/lectures/BCG_complete_mkts.md
+++ b/lectures/BCG_complete_mkts.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Irrelevance of Capital Structures with Complete Markets
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython
@@ -873,7 +869,6 @@ import matplotlib.pyplot as plt
 from scipy.stats import norm
 from numba import njit, prange
 from quantecon.optimize import root_finding
-%matplotlib inline
 ```
 
 ```{code-cell} python3

--- a/lectures/BCG_incomplete_mkts.md
+++ b/lectures/BCG_incomplete_mkts.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Equilibrium Capital Structures with Incomplete Markets
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/asset_pricing_lph.md
+++ b/lectures/asset_pricing_lph.md
@@ -17,10 +17,6 @@ kernelspec:
 ```{index} single: Elementary Asset Pricing
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This lecture is about  some implications of  asset-pricing theories that are based on the equation
@@ -356,7 +352,6 @@ In drawing a frontier, we'll set $\sigma(m) = .25$ and $E m = .99$, values rough
 ```{code-cell} ipython3
 import matplotlib.pyplot as plt
 import numpy as np
-%matplotlib inline
 
 # Define the function to plot
 def y(x, alpha, beta):

--- a/lectures/black_litterman.md
+++ b/lectures/black_litterman.md
@@ -23,10 +23,6 @@ kernelspec:
 
 # Two Modifications of Mean-Variance Portfolio Theory
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This lecture describes extensions to the classical mean-variance portfolio theory summarized in our lecture [Elementary Asset Pricing Theory](https://python-advanced.quantecon.org/asset_pricing_lph.html).
@@ -87,11 +83,8 @@ Let's start with some imports:
 import numpy as np
 import scipy.stats as stat
 import matplotlib.pyplot as plt
-%matplotlib inline
 from ipywidgets import interact, FloatSlider
 ```
-
-
 
 ## Mean-Variance Portfolio Choice
 

--- a/lectures/cake_eating_numerical.md
+++ b/lectures/cake_eating_numerical.md
@@ -11,10 +11,6 @@ kernelspec:
 
 # Cake Eating II: Numerical Methods
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will require the following library:
 
 ```{code-cell} ipython

--- a/lectures/cake_eating_problem.md
+++ b/lectures/cake_eating_problem.md
@@ -11,10 +11,6 @@ kernelspec:
 
 # Cake Eating I: Introduction to Optimal Saving
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 In this lecture we introduce a simple "cake eating" problem.

--- a/lectures/career.md
+++ b/lectures/career.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Modeling; Career Choice
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/coleman_policy_iter.md
+++ b/lectures/coleman_policy_iter.md
@@ -19,10 +19,6 @@ kernelspec:
 
 # {index}`Optimal Growth III: Time Iteration <single: Optimal Growth III: Time Iteration>`
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/harrison_kreps.md
+++ b/lectures/harrison_kreps.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Models; Harrison Kreps
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture uses following libraries:
 
 ```{code-cell} ipython

--- a/lectures/ifp.md
+++ b/lectures/ifp.md
@@ -19,10 +19,6 @@ kernelspec:
 
 # {index}`The Income Fluctuation Problem I: Basic Model <single: The Income Fluctuation Problem I: Basic Model>`
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/ifp_advanced.md
+++ b/lectures/ifp_advanced.md
@@ -19,10 +19,6 @@ kernelspec:
 
 # {index}`The Income Fluctuation Problem II: Stochastic Returns on Assets <single: The Income Fluctuation Problem II: Stochastic Returns on Assets>`
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/inventory_dynamics.md
+++ b/lectures/inventory_dynamics.md
@@ -22,10 +22,6 @@ kernelspec:
 ```{index} single: Markov process, inventory
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 In this lecture we will study the time path of inventories for firms that

--- a/lectures/jv.md
+++ b/lectures/jv.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Models; On-the-Job Search
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/kesten_processes.md
+++ b/lectures/kesten_processes.md
@@ -22,10 +22,6 @@ kernelspec:
 ```{index} single: Linear State Space Models
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/lake_model.md
+++ b/lectures/lake_model.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Lake Model
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/markov_asset.md
+++ b/lectures/markov_asset.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Models; Markov Asset Pricing
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ```{epigraph}
 "A little knowledge of geometric series goes a long way" -- Robert E. Lucas, Jr.
 ```

--- a/lectures/mccall_correlated.md
+++ b/lectures/mccall_correlated.md
@@ -19,10 +19,6 @@ kernelspec:
 
 # Job Search IV: Correlated Wage Offers
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/mccall_fitted_vfi.md
+++ b/lectures/mccall_fitted_vfi.md
@@ -19,10 +19,6 @@ kernelspec:
 
 # Job Search III: Fitted Value Function Iteration
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/mccall_model.md
+++ b/lectures/mccall_model.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Job Search I: The McCall Search Model
 
-```{contents} Contents
-:depth: 2
-```
-
 ```{epigraph}
 "Questioning a McCall worker is like having a conversation with an out-of-work friend:
 'Maybe you are setting your sights too high', or 'Why did you quit your old job before you

--- a/lectures/mccall_model_with_separation.md
+++ b/lectures/mccall_model_with_separation.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: An Introduction to Job Search
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/odu.md
+++ b/lectures/odu.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Job Search VII: Search with Learning
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what’s in Anaconda, this lecture deploys the libraries:
 
 ```{code-cell} ipython

--- a/lectures/optgrowth.md
+++ b/lectures/optgrowth.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # {index}`Optimal Growth I: The Stochastic Optimal Growth Model <single: Optimal Growth I: The Stochastic Optimal Growth Model>`
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 In this lecture, we're going to study a simple optimal growth model with one

--- a/lectures/optgrowth_fast.md
+++ b/lectures/optgrowth_fast.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # {index}`Optimal Growth II: Accelerating the Code with Numba <single: Optimal Growth II: Accelerating the Code with Numba>`
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/orth_proj.md
+++ b/lectures/orth_proj.md
@@ -23,10 +23,6 @@ kernelspec:
 ```{index} single: Orthogonal Projection
 ```
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 Orthogonal projection is a cornerstone of vector space methods, with many diverse applications.

--- a/lectures/samuelson.md
+++ b/lectures/samuelson.md
@@ -19,10 +19,6 @@ kernelspec:
 
 # Samuelson Multiplier-Accelerator
 
-```{contents} Contents
-:depth: 2
-```
-
 In addition to what's in Anaconda, this lecture will need the following libraries:
 
 ```{code-cell} ipython

--- a/lectures/sir_model.md
+++ b/lectures/sir_model.md
@@ -19,10 +19,6 @@ kernelspec:
 
 # {index}`Modeling COVID 19 <single: Modeling COVID 19>`
 
-```{contents} Contents
-:depth: 2
-```
-
 ## Overview
 
 This is a Python version of the code for analyzing the COVID-19 pandemic

--- a/lectures/troubleshooting.md
+++ b/lectures/troubleshooting.md
@@ -20,10 +20,6 @@ kernelspec:
 
 # Troubleshooting
 
-```{contents} Contents
-:depth: 2
-```
-
 This page is for readers experiencing errors when running the code from the lectures.
 
 ## Fixing Your Local Environment

--- a/lectures/wealth_dynamics.md
+++ b/lectures/wealth_dynamics.md
@@ -19,10 +19,6 @@ kernelspec:
 
 # Wealth Distribution Dynamics
 
-```{contents} Contents
-:depth: 2
-```
-
 ```{seealso}
 A [version of this lecture](https://jax.quantecon.org/wealth_dynamics.html) using a `GPU`
 is [available here](https://jax.quantecon.org/wealth_dynamics.html)


### PR DESCRIPTION
This PR addresses https://github.com/QuantEcon/meta/issues/134 and removes `contents` directives to simplify. 